### PR TITLE
Upgrade CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ name: CI
 
 # These trigger patterns courtesy of https://github.com/broccolijs/broccoli/pull/436
 on:
+  workflow_dispatch:
   pull_request:
   push:
     # filtering branches here prevents duplicate builds from pull_request and push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Install Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
+          cache: 'yarn'
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Lint JS
@@ -47,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Install Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 10
       - name: Install Dependencies
@@ -73,11 +74,12 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Install Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
+          cache: 'yarn'
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Try Scenario

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ on:
     # always run CI for tags
     tags:
       - "*"
-
   # early issue detection: run CI weekly on Sundays
   schedule:
     - cron: "0 6 * * 0"
@@ -26,7 +25,7 @@ env:
 jobs:
   test-locked-deps:
     name: Locked Deps
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1
@@ -45,7 +44,7 @@ jobs:
 
   test-old-dependencies:
     name: Oldest Supported Env
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1
@@ -60,7 +59,7 @@ jobs:
 
   test-try:
     name: Ember Try
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: [test-locked-deps]
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           - ember-release
           - ember-beta
           - ember-canary
+      fail-fast: false
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1


### PR DESCRIPTION
I wrote _Upgrade_ instead of fix ‘cause I still have a couple of issues to look into, but for now this will help follow-up work:
- Add `workflow_dispatch` to manually trigger builds (I’ve found that useful for certain debugging scenarios)
- Change Ubuntu version to `latest` (there is nothing particular we gain from pinning down out distro version)
- Bump Node actions to v2 and cache Yarn through them
- Set `fail-fast: false` to make sure all of our parallel builds run (instead of having them being cancelled because one failed)

After having these improvements merged in, we can look into how to fix the following (modern Ember versions don’t seem to play well with this addon):
<img width="263" alt="image" src="https://user-images.githubusercontent.com/385232/159086048-94cb6cc5-b158-440c-8b6d-4ea8b521e0a2.png">
